### PR TITLE
ci: change dependabot review team

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:
-      - "nl-design-system/sysadmin"
+      - "nl-design-system/dependabot"
     ignore:
       # We don't yet use Node 17 so the types of node should also be locked at 16.
       - dependency-name: "@types/node"


### PR DESCRIPTION
Enables us to easily add and remove people from 'dependabot review duty' and a step in the right direction to remove the root `kernteam-sysadmin`