### PR TITLE
fix: move workflow dispatch to separate job

### DIFF
--- a/.github/workflows/update-component-progress.yml
+++ b/.github/workflows/update-component-progress.yml
@@ -1,48 +1,8 @@
-name: Continuous Deployment
+name: Update component progress
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: workflow_dispatch:
 
 jobs:
-  continuous-integration:
-    name: Continuous integration
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download code from GitHub
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-
-      - name: Install pnpm package manager
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-
-      - name: Set up Node.js version
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Install dependencies specified in package.json
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm ls --recursive
-
-      - name: Run the lint script in package.json scripts
-        run: |
-          pnpm run --if-present lint
-
-      - name: Run the build script in package.json scripts
-        env:
-          GH_ISSUES_TOKEN: ${{ secrets.GH_ISSUES_TOKEN }}
-        run: |
-          pnpm run --if-present build
-
-      - name: Run the test script in package.json scripts
-        run: |
-          pnpm run --if-present test
-
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-latest
@@ -83,7 +43,7 @@ jobs:
           GIT_COMMITTER_NAME: "NL Design System"
         run: |
           git push --set-upstream origin HEAD
-          pnpm run release
+          pnpm run release:component-progress
 
       - name: Publish to npm repository
         env:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "prepare": "husky",
     "prettier": "prettier --write .",
     "publish": "lerna publish from-package --yes",
-    "release": "lerna version prerelease --conventional-prerelease --force-publish=@nl-design-system/component-progress --no-changelog --no-private --yes",
+    "release": "lerna version prerelease --conventional-prerelease --no-changelog --no-private --yes",
+    "release:component-progress": "lerna version prerelease --conventional-prerelease --force-publish=@nl-design-system/component-progress --no-changelog --no-private --yes",
     "update-patch": "npm-check-updates --configFileName .ncurc.patch.cjs",
     "update-minor": "npm-check-updates --configFileName .ncurc.minor.cjs",
     "update-major": "npm-check-updates --configFileName .ncurc.major.cjs"


### PR DESCRIPTION
We now had the issue of recurring releases as the check for changes was removed.

To ensure builds via manual workflow in Actions do not trigger such action I've split it into two separate jobs. One on push to `main` where we check if anything changed and one where we force-release component-progress when triggered manually.