### PR TITLE
chore: update dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Changes to any file require approval from @nl-design-system/kernteam-committer
+* @nl-design-system/kernteam-committer
+
+# Changes to this file (.github/CODEOWNERS) require approval from @nl-design-system/kernteam-admin
+.github/CODEOWNERS @nl-design-system/kernteam-admin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "nl-design-system/kernteam-dependabot"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -23,5 +21,3 @@ updates:
           - "version-update:semver-major"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
-    reviewers:
-      - "nl-design-system/kernteam-dependabot"


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

- Remove reviewers from `dependabot.yml`
- Add `.github/CODEOWNERS`