### PR TITLE
ci: enable pnpm audit to check for critical vulnerabilities

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Check for known security issues with npm packages
+        run: |
+          echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm audit --audit-level critical
+
       - name: Install dependencies specified in package.json
         run: |
           pnpm install --frozen-lockfile
@@ -61,6 +66,11 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: .nvmrc
+
+      - name: Check for known security issues with npm packages
+        run: |
+          echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm audit --audit-level critical
 
       - name: Install dependencies as specified in package.json
         run: |

--- a/.github/workflows/update-component-progress.yml
+++ b/.github/workflows/update-component-progress.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Check for known security issues with npm packages
+        run: |
+          echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm audit --audit-level critical
+
       - name: Install dependencies as specified in package.json
         run: |
           pnpm install --frozen-lockfile


### PR DESCRIPTION
And show a link for more information (i.e., what to do if your pipeline is blocked).