### PR TITLE
ci: ensure the "repository" field is correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": {
     "type": "git",
     "url": "github:nl-design-system/index",
-    "directory": "."
+    "directory": "packages/component-progress"
   },
   "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
   "engines": {


### PR DESCRIPTION
Prerequisite for provenance, as mentioned in https://docs.npmjs.com/generating-provenance-statements#prerequisites