### PR TITLE
Release new version of component-progress

### DIFF
--- a/.changeset/update-component-progress.md
+++ b/.changeset/update-component-progress.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system/component-progress': patch
+---
+
+Update component progress


### PR DESCRIPTION
Merge this PR, and then the changeset PR that follows, to release a new version of `@nl-design-system/component-progress`.

This PR is only needed now (once).  In the future, the changeset PR should always be available and only that PR will need to be merged.