### PR TITLE
ci: fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
       interval: "monthly"
     groups:
       github-actions:
-        applies-to: "version-updates"
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
Apparently there is an [undocumented](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--) requirement that this field is mandatory.

Found a cool package that can validate the config:
```
pnpm dlx @bugron/validate-dependabot-yaml .github/dependabot.yml
```