### PR TITLE
ci: don't persist credentials in actions/checkout

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Download code from GitHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4


### PR DESCRIPTION
This PR updates the `actions/checkout` action to not persist credentials by default.

This is a security best practice.

See https://github.com/nl-design-system/beheer/issues/31 for more details.
