### PR TITLE
Only include community components with green status

### DIFF
--- a/.changeset/lemon-bananas-go.md
+++ b/.changeset/lemon-bananas-go.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system/component-progress': minor
+---
+
+Only include community components with a green status field (anything else = opt out)

--- a/packages/component-progress/src/utils/mapToComponentProgress.ts
+++ b/packages/component-progress/src/utils/mapToComponentProgress.ts
@@ -2,6 +2,15 @@ import isEmpty from 'lodash.isempty';
 import { type MappedProjects, PROJECT_NUMBERS, PROJECTS } from './index.js';
 import type { ComponentIssue, ProjectFieldValue, ProjectItem } from '../graphql/getComponentIssues.js';
 
+const isCommunityOrganizationBoard = (project: ProjectItem['project']): boolean =>
+  project.title.startsWith('Community Components - ');
+
+const isSharedWithCommunity = (fieldValues: ProjectItem['fieldValues']): boolean => {
+  const statusField = fieldValues.nodes.find((node) => !isEmpty(node) && node.field?.name === 'Status');
+
+  return statusField?.color === 'GREEN';
+};
+
 const cleanupValue = ({ field, value, color }: ProjectFieldValue) => {
   // Only allow https values
   if (field.dataType === 'TEXT' && typeof value === 'string' && URL.canParse(value)) {
@@ -129,6 +138,9 @@ export const mapToComponentProgress = (issues: ComponentIssue[], projects: Mappe
       ...issue,
       projects: projectItems.nodes
         .filter(({ project }) => Object.values(PROJECT_NUMBERS).includes(project.number))
+        .filter(
+          ({ project, fieldValues }) => !isCommunityOrganizationBoard(project) || isSharedWithCommunity(fieldValues),
+        )
         .map(cleanupFields)
         .map((component) => getAllTasks(component, projects)),
     }))


### PR DESCRIPTION
Fixes https://github.com/nl-design-system/index/issues/551

Note: 
- [ ] project boards need to be updated and checked whether the status column is properly configured (is the Beschikbaar status green?)
- [ ] and whether the status is properly filled

Some (see RVO project board on 24/6) are empty.  After merging this without updating the status, these components would disappear from the website.  The original GitHub issue is worded like you can opt out, but with this change, you actually have to opt in.
