### PR TITLE
chore: upgrade npm-check-updates to 22

### DIFF
--- a/.ncurc.major.mjs
+++ b/.ncurc.major.mjs
@@ -1,6 +1,6 @@
-const minorConfig = require('./.ncurc.minor.cjs');
+import minorConfig from './.ncurc.minor.mjs';
 
-module.exports = {
+export default {
   ...minorConfig,
   reject: [...minorConfig.reject],
   target: 'latest',

--- a/.ncurc.minor.mjs
+++ b/.ncurc.minor.mjs
@@ -1,6 +1,6 @@
-const patchConfig = require('./.ncurc.patch.cjs');
+import patchConfig from './.ncurc.patch.mjs';
 
-module.exports = {
+export default {
   ...patchConfig,
   reject: [...patchConfig.reject],
   target: 'minor',

--- a/.ncurc.patch.mjs
+++ b/.ncurc.patch.mjs
@@ -1,5 +1,4 @@
-module.exports = {
-  cooldown: 1, // 1 day
+export default {
   dep: ['dev', 'prod'],
   install: 'always',
   reject: [],

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "husky": "9.1.7",
     "lint-staged": "16.2.7",
     "markdownlint-cli": "0.47.0",
-    "npm-check-updates": "19.3.2",
+    "npm-check-updates": "22.2.9",
     "npm-package-json-lint": "9.1.0",
     "prettier": "3.8.1",
     "rimraf": "6.1.2",
@@ -55,8 +55,8 @@
     "changeset:empty": "changeset add --empty",
     "changeset:publish": "changeset publish",
     "changeset:status": "changeset status --since origin/main",
-    "update-patch": "npm-check-updates --configFileName .ncurc.patch.cjs",
-    "update-minor": "npm-check-updates --configFileName .ncurc.minor.cjs",
-    "update-major": "npm-check-updates --configFileName .ncurc.major.cjs"
+    "update-patch": "npm-check-updates --configFileName .ncurc.patch.mjs",
+    "update-minor": "npm-check-updates --configFileName .ncurc.minor.mjs",
+    "update-major": "npm-check-updates --configFileName .ncurc.major.mjs"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 0.47.0
         version: 0.47.0
       npm-check-updates:
-        specifier: 19.3.2
-        version: 19.3.2
+        specifier: 22.2.9
+        version: 22.2.9
       npm-package-json-lint:
         specifier: 9.1.0
         version: 9.1.0(typescript@5.9.3)
@@ -1626,9 +1626,9 @@ packages:
     resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
     engines: {node: '>=10'}
 
-  npm-check-updates@19.3.2:
-    resolution: {integrity: sha512-9rr3z7znFjCSuaFxHGTFR2ZBOvLWaJcpLKmIquoTbDBNrwAGiHhv4MZyty6EJ9Xo/aMn35+2ISPSMgWIXx5Xkg==}
-    engines: {node: '>=20.0.0', npm: '>=8.12.1'}
+  npm-check-updates@22.2.9:
+    resolution: {integrity: sha512-DVeZ0KirHfliSsHuR2o7cHE+tW439sVHfJjF6cGWeDiY0Wyl3BI/jS4zV0eixtcMOquFbcF1Su/FsxOvk5MoYA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10.0.0'}
     hasBin: true
 
   npm-package-json-lint@9.1.0:
@@ -4152,7 +4152,7 @@ snapshots:
       semver: 7.7.3
       validate-npm-package-license: 3.0.4
 
-  npm-check-updates@19.3.2: {}
+  npm-check-updates@22.2.9: {}
 
   npm-package-json-lint@9.1.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Since v21 there is ESM support; updated config accordingly.

Since v20 the cooldown is taken from pnpm config; removed cooldown from ncu config.
